### PR TITLE
Accessibility: [fixes for images, etc]

### DIFF
--- a/adventure/templates/about.html
+++ b/adventure/templates/about.html
@@ -10,7 +10,7 @@
 <div class="container-fluid">
   <div class="parchment">
     <div class="parchment-inner">
-      <h2><img src="{% static "images/ravenmore/128/scroll.png" %}"> About Eamon</h2>
+      <h2><img src="{% static "images/ravenmore/128/scroll.png" %}" alt="Scroll"> About Eamon</h2>
       <p>Far away, at the dead center of the Milky Way, is the planet Eamon. It doesn't orbit any suns, two great suns orbit it! The shifting pull from these great bodies bring strange forces to bear upon this planet; twisting light, tides, even the laws of science itself! Strange things happen on Planet Eamon, and the citizens must always be adaptable, for things are rarely what they seem, and quite often not the same as they were from one day to the next!</p>
 
       <p>Eamon is played through characters who are members of the famous Free Adventurer's Guild. Free Adventurers are men and women who have dared to seek their fortune in the marvelous world of shifting laws and time. Players will often find their characters fighting terrible monsters such as orcs, trolls, and dragons, and claiming various riches and treasure as their own. However, Planet Eamon is bound by no laws of time or space. Anything can happen once an adventure has been started. At any random time, a character could end up facing such varied opponents as Billy the Kid or Darth Vader!</p>

--- a/adventure/templates/adventure-list.html
+++ b/adventure/templates/adventure-list.html
@@ -8,13 +8,13 @@
 <div class="container">
   <div class="parchment">
     <div class="parchment-inner">
-      <h2><img src="{% static "images/ravenmore/128/map.png" %}"> Adventures</h2>
+      <h2><img src="{% static "images/ravenmore/128/map.png" %}" alt="Map" /> Adventures</h2>
       <p>Eamon contains many different adventures of many different styles. Some are fantasy or sci-fi, contain a quest or just hack-and-slash. Some are aimed at beginners and others are for veteran adventurers only. Choose your fate and perish (or profit)...</p>
       <div class="adventure-list margin-bottom-lg">
         {% for adv in adventures %}
         <div class="adventure-list-item">
           <div class="row">
-            <div class="col-3 col-md-2"><img src="/static/images/ravenmore/128/map.png" width="64"></div>
+            <div class="col-3 col-md-2"><img src="/static/images/ravenmore/128/map.png" width="64" aria-hidden="true" /></div>
             <div class="col-9 col-md-10">
               <h3>{{ adv.name }}</h3>
               {% if adv.authors %}

--- a/adventure/templates/index.html
+++ b/adventure/templates/index.html
@@ -12,10 +12,10 @@
         <div class="col-md-7 col-sm-8">
           <h2>Welcome to EAMON!</h2>
           <p class="lead">Eamon is a computerized fantasy role-playing system. Create one character and go on dozens of different adventures!<p>
-          <p id="intro-link"><a href="{% url 'main-hall' %}"><img src="/static/images/ravenmore/128/map.png"> Enter the Main Hall</a></p>
+          <p id="intro-link"><a href="{% url 'main-hall' %}"><img src="/static/images/ravenmore/128/map.png" aria-hidden="true"> Enter the Main Hall</a></p>
         </div>
         <div class="col-md-5 col-sm-4 text-center">
-          <img src="/static/images/Eamon_dragon_NEUC.png" width="375" id="intro-dragon">
+          <img src="/static/images/Eamon_dragon_NEUC.png" width="375" id="intro-dragon" alt="The Eamon Dragon">
         </div>
         <div class="col-md-12">
           <p><small>Based on the Eamon Adventure Series, written by Donald Brown for the Apple ][, and on Eamon Deluxe by Frank Black.</small></p>

--- a/adventure/templates/manual.html
+++ b/adventure/templates/manual.html
@@ -9,7 +9,7 @@
   <div class="parchment">
     <div class="parchment-inner">
 
-      <h2><img src="{% static "images/ravenmore/128/tome.png" %}"> Adventurer's Manual</h2>
+      <h2><img src="{% static "images/ravenmore/128/tome.png" %}" alt="Spell book" /> Adventurer's Manual</h2>
 
       <p>Eamon is a combination of a text-based interactive fiction game (like Adventure, Zork, etc.) and a fantasy role-playing game. Players create a character, journey on various adventures, and interact with the game world using English-like commands. Players explore pre-mapped adventures, fighting vicious and often humorous foes, collecting loot, and locating keys, magic items, or other special objects which allow them to proceed on through the plot.</p>
 

--- a/client/main-hall/components/AdventureList.tsx
+++ b/client/main-hall/components/AdventureList.tsx
@@ -179,7 +179,7 @@ class AdventureList extends React.Component<any, any> {
 
     return (
       <div id="AdventureList">
-        <h2><img src="/static/images/ravenmore/128/map.png" /> Go on an adventure</h2>
+        <h2><img src="/static/images/ravenmore/128/map.png" alt="Map" /> Go on an adventure</h2>
 
         {message}
 

--- a/client/main-hall/components/Bank.tsx
+++ b/client/main-hall/components/Bank.tsx
@@ -61,7 +61,7 @@ export default class Bank extends React.Component<any, any> {
 
     return (
       <div className="bank">
-        <h2><img src="/static/images/ravenmore/128/coin.png" />Bank of Eamon Towne</h2>
+        <h2><img src="/static/images/ravenmore/128/coin.png" alt="Gold coin" />Bank of Eamon Towne</h2>
         <p>You have no trouble spotting Shylock McFenney, the local banker, due to his large belly. You attract his attention, and he comes over to you.</p>
         <p>&quot;Well, {this.props.player.name}, my dear {this.props.player.gender === 'm' ? 'boy' : 'lass'}, what a pleasure
           to see you! Do you want to make a deposit or a withdrawal?&quot;</p>

--- a/client/main-hall/components/PlayerListItem.tsx
+++ b/client/main-hall/components/PlayerListItem.tsx
@@ -52,12 +52,12 @@ class PlayerListItem extends React.Component<any, any> {
 
     return (
       <div className="player col-sm-6 col-md-4" key={this.state.player.id}>
-        <div className="icon"><img src={icon_url} width="96" height="96"/></div>
+        <div className="icon"><img src={icon_url} width="96" height="96" aria-hidden="true" /></div>
         <div className="name"><a className="player_name" onClick={() => this.loadPlayer()}><strong>{this.state.player.name}</strong></a>
           <br/>
           HD: {this.state.player.hardiness} AG: {this.state.player.agility} CH: {this.state.player.charisma} <br/>
           {ucFirst(weapon_name)}</div>
-        <div className="delete"><button className="btn btn-link" onClick={() => this.deletePlayer(this.state.player)}><img src="/static/images/ravenmore/128/x.png" title="delete" /></button></div>
+        <div className="delete"><button className="btn btn-link" aria-label="Delete" onClick={() => this.deletePlayer(this.state.player)}><img src="/static/images/ravenmore/128/x.png" title="delete" /></button></div>
       </div>
     );
   }

--- a/client/main-hall/components/PlayerMenu.tsx
+++ b/client/main-hall/components/PlayerMenu.tsx
@@ -27,26 +27,26 @@ class PlayerMenu extends React.Component<any, any> {
           <p>You are in the main hall of the Guild of Free Adventurers. You can do the following:</p>
           <nav className="row icon-nav">
             <p className="col-6 col-lg-4">
-              <Link to="/main-hall/adventure"><img src="/static/images/ravenmore/128/map.png" /><br />
+              <Link to="/main-hall/adventure"><img src="/static/images/ravenmore/128/map.png" aria-hidden="true" /><br />
                 Go on an adventure</Link>
             </p>
             <p className="col-6 col-lg-4">
-              <Link to="/main-hall/shop"><img src="/static/images/ravenmore/128/axe2.png" /><br />
+              <Link to="/main-hall/shop"><img src="/static/images/ravenmore/128/axe2.png" aria-hidden="true" /><br />
                 Visit the weapons shop</Link>
             </p>
             <p className="col-6 col-lg-4">
-              <Link to="/main-hall/wizard"><img src="/static/images/ravenmore/128/tome.png" /><br />
+              <Link to="/main-hall/wizard"><img src="/static/images/ravenmore/128/tome.png" aria-hidden="true" /><br />
                 Find a wizard to teach you some spells</Link></p>
             <p className="col-6 col-lg-4">
-              <Link to="/main-hall/witch"><img src="/static/images/ravenmore/128/potion.png" /><br />
+              <Link to="/main-hall/witch"><img src="/static/images/ravenmore/128/potion.png" aria-hidden="true" /><br />
                 Visit the witch to increase your attributes</Link>
             </p>
             <p className="col-6 col-lg-4">
-              <Link to="/main-hall/bank"><img src="/static/images/ravenmore/128/coin.png" /><br />
+              <Link to="/main-hall/bank"><img src="/static/images/ravenmore/128/coin.png" aria-hidden="true" /><br />
                 Find the banker to deposit or withdraw some gold</Link>
             </p>
             <p className="col-6 col-lg-4">
-              <a onClick={this.exit} className="link"><img src="/static/images/ravenmore/128/x.png" /><br />
+              <a onClick={this.exit} className="link"><img src="/static/images/ravenmore/128/x.png" aria-hidden="true" /><br />
                 Temporarily leave the universe</a></p>
           </nav>
         </div>

--- a/client/main-hall/components/Shop/ArtifactTile.tsx
+++ b/client/main-hall/components/Shop/ArtifactTile.tsx
@@ -69,14 +69,14 @@ class ArtifactTile extends React.Component<any, any> {
       <div className="artifact-tile col-sm-6 col-md-4 col-lg-3">
         <div className="artifact-tile-inner">
           <div className="artifact-icon">
-            <img src={icon_url} title="{ this.props.artifact.getTypeName() }" />
+            <img src={icon_url} title={ this.props.artifact.getTypeName() } />
           </div>
           <div className="artifact-name">
             <strong>{ ucFirst(this.props.artifact.name) }</strong><br />
           </div>
           <div className="artifact-data">
             {stats}
-            <img src="/static/images/ravenmore/128/coin.png" /> {value}
+            <img src="/static/images/ravenmore/128/coin.png" title="gold coin" /> {value}
           </div>
           <div className="artifact-buttons">
             {button}

--- a/client/main-hall/components/Shop/Shop.tsx
+++ b/client/main-hall/components/Shop/Shop.tsx
@@ -24,7 +24,7 @@ class Shop extends React.Component<any, any> {
 
     return (
       <div className="shop">
-        <h2><img src="/static/images/ravenmore/128/axe2.png" />Marcos Cavielli's Weapons and Armour Shoppe</h2>
+        <h2><img src="/static/images/ravenmore/128/axe2.png" alt="Battle axe" />Marcos Cavielli's Weapons and Armour Shoppe</h2>
 
         <Route path="/main-hall/shop" exact={true} render={(props) => (
           <div className="shop-home">

--- a/client/main-hall/components/Witch/Witch.tsx
+++ b/client/main-hall/components/Witch/Witch.tsx
@@ -28,7 +28,7 @@ class Witch extends React.Component<any, any> {
 
     return (
       <div className="witch-shop">
-        <h2><img src="/static/images/ravenmore/128/potion.png" />The Witch's Shop</h2>
+        <h2><img src="/static/images/ravenmore/128/potion.png" alt="Potion" />The Witch's Shop</h2>
         <p>A lovely young woman dressed in black says, &quot;Good day, { this.props.player.name }! Ah, I see you're surprised I know your name? I also know that your Hardiness is { this.props.player.hardiness } your Agility
     is { this.props.player.agility }, and your Charisma is { this.props.player.charisma }.&quot;</p>
   <p>&quot;My magic potions can increase one of your attributes. My prices are:&quot;</p>

--- a/client/main-hall/components/Wizard/Wizard.tsx
+++ b/client/main-hall/components/Wizard/Wizard.tsx
@@ -36,7 +36,7 @@ class Wizard extends React.Component<any, any> {
 
     return (
       <div className="wizard-shop">
-        <h2><img src="/static/images/ravenmore/128/tome.png" alt="Tome" />Hokas Tokas' School of Magick</h2>
+        <h2><img src="/static/images/ravenmore/128/tome.png" alt="Tome" alt="Spell book" />Hokas Tokas' School of Magick</h2>
         <p>After a few minutes of diligent searching, you find Hokas Tokas, the old Mage. He looks at you and says, &quot;So you want old Hokey to teach you some magic, eh? Well, it'll cost you. Here are the spells I teach. Which will it be?&quot;</p>
         <div className="spells-list">
           {this.state.spells.map(spell =>

--- a/news/templates/news.html
+++ b/news/templates/news.html
@@ -8,7 +8,7 @@
 <div class="container-fluid">
   <div class="parchment">
     <div class="parchment-inner">
-      <h2><img src="{% static "images/ravenmore/128/scroll.png" %}"> News</h2>
+      <h2><img src="{% static "images/ravenmore/128/scroll.png" %}" alt="Scroll" /> News</h2>
       <div class="row">
         {% for a in articles %}
         <div class="news-list-item col-sm-12">


### PR DESCRIPTION
If you are interested—This includes all accessibility fixes I'm aware of across the Main Hall, Shop, Wizard, Bank, Witch, Adventure List, News, About, Manual, etc. Most are descriptions provided for icons. The "Delete" buttons for player characters in the guestbook were also unlabelled for screen readers and are fixed in this commit. A very small number of icons are now ignored entirely by the screen reader, since they only served to confuse/clutter output. The weapon class icons in the Shop had the code to pull the weapon class into the title attribute was enclosed in "" which caused it to be rendered as code to the screen reader since that code was never executing. I removed the quotes so it now behaves properly.

Codewise, these changes are very minor and should result in no changes visually. They make a tremendous difference to the experience of screen reader users, though.